### PR TITLE
Update Aurora Serverless PostgreSQL Engine Version to VER_16_6


### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 ## 2024-12-07
 
 ### Changed
+- Updated Aurora Serverless PostgreSQL engine version from `VER_17_2` to `VER_16_6`
+- Maintained existing database cluster engine configuration and conditional removal policy
+- Preserved environment-specific database cluster management approach
+
+## 2024-12-07
+
+### Changed
 - Updated `APP_NAME` in `.env.example` from `aws-aurora-serverless` to `ow-aurora-serverless`
 
 ### Added

--- a/lib/aws-aurora-serverless-stack.ts
+++ b/lib/aws-aurora-serverless-stack.ts
@@ -31,7 +31,7 @@ export class AwsAuroraServerlessStack extends cdk.Stack {
     const removalPolicy = props.deployEnvironment === 'production' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY;
     const auroraDatabaseCluster = new rds.DatabaseCluster(this, `${props.resourcePrefix}-Aurora-Serverless`, {
       engine: props.auroraEngine === AuroraEngine.AuroraPostgresql ?
-        rds.DatabaseClusterEngine.auroraPostgres({ version: rds.AuroraPostgresEngineVersion.VER_17_2 }) :
+        rds.DatabaseClusterEngine.auroraPostgres({ version: rds.AuroraPostgresEngineVersion.VER_16_6 }) :
         rds.DatabaseClusterEngine.auroraMysql({ version: rds.AuroraMysqlEngineVersion.VER_3_08_0 }),
       vpc,
       vpcSubnets: {


### PR DESCRIPTION
### **PR Type**
Configuration


___

### **PR Description**
- Updated PostgreSQL version for Aurora Serverless database cluster from `VER_17_2` to `VER_16_6`
- Maintains the existing configuration for database cluster engine selection
- Preserves conditional removal policy based on deployment environment

