### PR TITLE
Update CDK Dependencies and Aurora PostgreSQL Engine Version


### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 ## 2024-12-07
 
 ### Changed
+- Updated Aurora Serverless PostgreSQL engine version from `VER_17_2` to `VER_16_6`
+- Maintained existing database cluster engine configuration and conditional removal policy
+- Preserved environment-specific database cluster management approach
+
+## 2024-12-07
+
+### Changed
 - Updated `APP_NAME` in `.env.example` from `aws-aurora-serverless` to `ow-aurora-serverless`
 
 ### Added

--- a/lib/aws-aurora-serverless-stack.ts
+++ b/lib/aws-aurora-serverless-stack.ts
@@ -31,7 +31,7 @@ export class AwsAuroraServerlessStack extends cdk.Stack {
     const removalPolicy = props.deployEnvironment === 'production' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY;
     const auroraDatabaseCluster = new rds.DatabaseCluster(this, `${props.resourcePrefix}-Aurora-Serverless`, {
       engine: props.auroraEngine === AuroraEngine.AuroraPostgresql ?
-        rds.DatabaseClusterEngine.auroraPostgres({ version: rds.AuroraPostgresEngineVersion.VER_17_2 }) :
+        rds.DatabaseClusterEngine.auroraPostgres({ version: rds.AuroraPostgresEngineVersion.VER_16_6 }) :
         rds.DatabaseClusterEngine.auroraMysql({ version: rds.AuroraMysqlEngineVersion.VER_3_08_0 }),
       vpc,
       vpcSubnets: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-aurora-serverless",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-aurora-serverless",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "aws-cdk-lib": "2.173.0",
         "cdk-nag": "^2.34.23",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "aws-aurora-serverless",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk-lib": "2.172.0",
-        "cdk-nag": "^2.34.18",
+        "aws-cdk-lib": "2.173.0",
+        "cdk-nag": "^2.34.23",
         "constructs": "^10.4.2",
         "dotenv": "^16.4.7"
       },
@@ -19,17 +19,17 @@
       "devDependencies": {
         "@tsconfig/node22": "^22.0.0",
         "@types/jest": "^29.5.14",
-        "@types/node": "22.10.1",
+        "@types/node": "22.10.2",
         "@types/source-map-support": "^0.5.10",
-        "aws-cdk": "2.172.0",
+        "aws-cdk": "2.173.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
         "typescript": "~5.7.2"
       },
       "peerDependencies": {
-        "aws-cdk": "2.172.0",
-        "aws-cdk-lib": "2.172.0",
+        "aws-cdk": "2.173.0",
+        "aws-cdk-lib": "2.173.0",
         "constructs": "^10.4.2"
       }
     },
@@ -1136,9 +1136,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.10.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
-      "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
+      "version": "22.10.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
+      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1286,9 +1286,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.172.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.172.0.tgz",
-      "integrity": "sha512-kacztcAl12F6zlBqKCuzCZmj4vrbMhzgDAxBB4T7fXR2amQyuu6W0nWcGWWvASXeBJcw2DJ6ulpfV4wuc9dksw==",
+      "version": "2.173.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.173.0.tgz",
+      "integrity": "sha512-riRGKSo5dzB0MSbdkZwXRC2t//dI220bgEUfVISilcEafBKj+BPzFBd/eNKuP/dEaS31njkCwtYrS7V7/lV4hQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1302,9 +1302,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.172.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.172.0.tgz",
-      "integrity": "sha512-SbFn2FyKhsHQpS7M3qeMWnRKtBHELkY3rmejk07cPlJ/BCJk/af8eKyeiNEEB0AZSfIeP4ImZCLNy9JS34mlPw==",
+      "version": "2.173.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.173.0.tgz",
+      "integrity": "sha512-Da1JUwG8eL+chRSB+c2I4dRf54DWe/wmWKj9CBthNdsE9XCB8odyEcMpmgBC+R160o7ioYY2DBsAaKIIRa9XQw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1894,9 +1894,9 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/cdk-nag": {
-      "version": "2.34.18",
-      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.34.18.tgz",
-      "integrity": "sha512-Sg6eQ6C+WGTutdy5zw80tdevVZDcK50zijz7DFAOpb6gFeTl2/YsPH/YgQFMuX3Au/RfHRhhQadkh2GUdSpAxA==",
+      "version": "2.34.23",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.34.23.tgz",
+      "integrity": "sha512-TCvQy5uCk1QHek7UhbmFh4Uk2HveXyuQ6jfUC0ZfW5HgAMhv8+6lTY56Jq09/rm0csKDzWnMpGGAXjgLW6rg0A==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "aws-cdk-lib": "^2.156.0",

--- a/package.json
+++ b/package.json
@@ -13,23 +13,23 @@
   "devDependencies": {
     "@tsconfig/node22": "^22.0.0",
     "@types/jest": "^29.5.14",
-    "@types/node": "22.10.1",
+    "@types/node": "22.10.2",
     "@types/source-map-support": "^0.5.10",
-    "aws-cdk": "2.172.0",
+    "aws-cdk": "2.173.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "typescript": "~5.7.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.172.0",
-    "cdk-nag": "^2.34.18",
+    "aws-cdk-lib": "2.173.0",
+    "cdk-nag": "^2.34.23",
     "constructs": "^10.4.2",
     "dotenv": "^16.4.7"
   },
   "peerDependencies": {
-    "aws-cdk": "2.172.0",
-    "aws-cdk-lib": "2.172.0",
+    "aws-cdk": "2.173.0",
+    "aws-cdk-lib": "2.173.0",
     "constructs": "^10.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-aurora-serverless",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "bin": {
     "aws-aurora-serverless": "bin/aws-aurora-serverless.js"
   },


### PR DESCRIPTION
### **PR Type**
Dependencies, Configuration


___

### **PR Description**
- Updated AWS CDK and related dependencies to newer versions
  - Upgraded `aws-cdk` from `2.172.0` to `2.173.0`
  - Updated `aws-cdk-lib` from `2.172.0` to `2.173.0`
  - Updated `@types/node` from `22.10.1` to `22.10.2`
  - Updated `cdk-nag` from `2.34.18` to `2.34.23`
- Changed Aurora PostgreSQL engine version from `VER_17_2` to `VER_16_6`
- Bumped project version from `0.1.0` to `0.1.1`

