### PR TITLE
Configure KMS Key with Explicit Removal Policy and Encryption Settings


### DIFF
--- a/lib/aws-aurora-serverless-stack.ts
+++ b/lib/aws-aurora-serverless-stack.ts
@@ -21,21 +21,21 @@ export class AwsAuroraServerlessStack extends cdk.Stack {
     // define subnetAttributes as an array of Record<string, string> with subnetId comes from props.vpcPrivateSubnetIds and availabilityZone comes from props.vpcPrivateSubnetAzs
     const subnetAttributes: Record<string, string>[] = props.vpcPrivateSubnetIds.map((subnetId, index) => {
       return {
-          subnetId: subnetId,
-          availabilityZone: props.vpcPrivateSubnetAzs[index],
-          routeTableId: props.vpcPrivateSubnetRouteTableIds[index],
-          type: vpcSubnetType,
+        subnetId: subnetId,
+        availabilityZone: props.vpcPrivateSubnetAzs[index],
+        routeTableId: props.vpcPrivateSubnetRouteTableIds[index],
+        type: vpcSubnetType,
       };
     });
     console.log('subnetAttributes:', JSON.stringify(subnetAttributes));
 
     // retrieve subnets from vpc
     const vpcPrivateISubnets: cdk.aws_ec2.ISubnet[] = subnetAttributes.map((subnetAttribute) => {
-        return ec2.Subnet.fromSubnetAttributes(this, subnetAttribute.subnetId, {
-            subnetId: subnetAttribute.subnetId,
-            availabilityZone: subnetAttribute.availabilityZone,
-            routeTableId: subnetAttribute.routeTableId,
-        });
+      return ec2.Subnet.fromSubnetAttributes(this, subnetAttribute.subnetId, {
+        subnetId: subnetAttribute.subnetId,
+        availabilityZone: subnetAttribute.availabilityZone,
+        routeTableId: subnetAttribute.routeTableId,
+      });
     });
     const vpcSubnetSelection: SubnetSelection = vpc.selectSubnets({
       subnets: vpcPrivateISubnets,
@@ -45,6 +45,10 @@ export class AwsAuroraServerlessStack extends cdk.Stack {
 
     const kmsKey = new kms.Key(this, `${props.resourcePrefix}-Aurora-KMS-Key`, {
       enableKeyRotation: true,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      enabled: true,
+      keyUsage: kms.KeyUsage.ENCRYPT_DECRYPT,
+      keySpec: kms.KeySpec.SYMMETRIC_DEFAULT,
     });
 
     const auroraPort = props.auroraEngine === AuroraEngine.AuroraPostgresql ? 5432 : 3306;


### PR DESCRIPTION
### **PR Type**
Configuration


___

### **PR Description**
- Updated the KMS key configuration in the `AwsAuroraServerlessStack` class
- Added explicit configuration for KMS key properties:
  - Set `removalPolicy` to `DESTROY`
  - Enabled the key
  - Specified `keyUsage` as `ENCRYPT_DECRYPT`
  - Set `keySpec` to `SYMMETRIC_DEFAULT`
- Minor formatting improvements in subnet and subnet attribute handling

