### PR TITLE
Dont allow outbound traffic by default for auroraSecurityGroup

### DIFF
--- a/lib/aws-aurora-serverless-stack.ts
+++ b/lib/aws-aurora-serverless-stack.ts
@@ -53,6 +53,7 @@ export class AwsAuroraServerlessStack extends cdk.Stack {
     const auroraPort = props.auroraEngine === AuroraEngine.AuroraPostgresql ? 5432 : 3306;
     const auroraSecurityGroup = new ec2.SecurityGroup(this, `${props.resourcePrefix}-Aurora-Security-Group`, {
       vpc,
+      allowAllOutbound: false,
       description: 'Security group for Aurora Serverless cluster',
     });
     auroraSecurityGroup.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);

--- a/lib/aws-aurora-serverless-stack.ts
+++ b/lib/aws-aurora-serverless-stack.ts
@@ -40,7 +40,6 @@ export class AwsAuroraServerlessStack extends cdk.Stack {
     const vpcSubnetSelection: SubnetSelection = vpc.selectSubnets({
       subnets: vpcPrivateISubnets,
       availabilityZones: props.vpcPrivateSubnetAzs,
-      subnetType: vpcSubnetType,
     });
 
     const kmsKey = new kms.Key(this, `${props.resourcePrefix}-Aurora-KMS-Key`, {
@@ -54,7 +53,6 @@ export class AwsAuroraServerlessStack extends cdk.Stack {
     const auroraPort = props.auroraEngine === AuroraEngine.AuroraPostgresql ? 5432 : 3306;
     const auroraSecurityGroup = new ec2.SecurityGroup(this, `${props.resourcePrefix}-Aurora-Security-Group`, {
       vpc,
-      allowAllOutbound: false,
       description: 'Security group for Aurora Serverless cluster',
     });
     auroraSecurityGroup.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);


### PR DESCRIPTION
### **PR Type**
Configuration


___

### **PR Description**
- Modified the `AwsAuroraServerlessStack` configuration in `lib/aws-aurora-serverless-stack.ts`
- Removed `subnetType` parameter from `vpc.selectSubnets()` method
- Removed `allowAllOutbound: false` configuration from `auroraSecurityGroup` creation
