### PR TITLE
Update AWS CDK dependencies to version 2.173.2 and increment project version


### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "aws-aurora-serverless",
       "version": "0.1.1",
       "dependencies": {
-        "aws-cdk-lib": "2.173.0",
+        "aws-cdk-lib": "2.173.2",
         "cdk-nag": "^2.34.23",
         "constructs": "^10.4.2",
         "dotenv": "^16.4.7"
@@ -21,15 +21,15 @@
         "@types/jest": "^29.5.14",
         "@types/node": "22.10.2",
         "@types/source-map-support": "^0.5.10",
-        "aws-cdk": "2.173.0",
+        "aws-cdk": "2.173.2",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
         "typescript": "~5.7.2"
       },
       "peerDependencies": {
-        "aws-cdk": "2.173.0",
-        "aws-cdk-lib": "2.173.0",
+        "aws-cdk": "2.173.2",
+        "aws-cdk-lib": "2.173.2",
         "constructs": "^10.4.2"
       }
     },
@@ -1286,9 +1286,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.173.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.173.0.tgz",
-      "integrity": "sha512-riRGKSo5dzB0MSbdkZwXRC2t//dI220bgEUfVISilcEafBKj+BPzFBd/eNKuP/dEaS31njkCwtYrS7V7/lV4hQ==",
+      "version": "2.173.2",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.173.2.tgz",
+      "integrity": "sha512-qyMU4FoRJdZDUpsOBqyRBALBjf5A2N/MaHKX9iJUkbTET+d+nR07x3ai4TcEES+8pqPFHMTKpQMRDXs9Py/15w==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1302,9 +1302,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.173.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.173.0.tgz",
-      "integrity": "sha512-Da1JUwG8eL+chRSB+c2I4dRf54DWe/wmWKj9CBthNdsE9XCB8odyEcMpmgBC+R160o7ioYY2DBsAaKIIRa9XQw==",
+      "version": "2.173.2",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.173.2.tgz",
+      "integrity": "sha512-cL9+z8Pl3VZGoO7BwdsrFAOeud/vSl3at7OvmhihbNprMN15XuFUx/rViAU5OI1m92NbV4NBzYSLbSeCwYLNyw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-aurora-serverless",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-aurora-serverless",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "aws-cdk-lib": "2.173.2",
         "cdk-nag": "^2.34.23",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-aurora-serverless",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "bin": {
     "aws-aurora-serverless": "bin/aws-aurora-serverless.js"
   },

--- a/package.json
+++ b/package.json
@@ -15,21 +15,21 @@
     "@types/jest": "^29.5.14",
     "@types/node": "22.10.2",
     "@types/source-map-support": "^0.5.10",
-    "aws-cdk": "2.173.0",
+    "aws-cdk": "2.173.2",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "typescript": "~5.7.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.173.0",
+    "aws-cdk-lib": "2.173.2",
     "cdk-nag": "^2.34.23",
     "constructs": "^10.4.2",
     "dotenv": "^16.4.7"
   },
   "peerDependencies": {
-    "aws-cdk": "2.173.0",
-    "aws-cdk-lib": "2.173.0",
+    "aws-cdk": "2.173.2",
+    "aws-cdk-lib": "2.173.2",
     "constructs": "^10.4.2"
   }
 }


### PR DESCRIPTION
### **PR Type**
Dependencies, Configuration


___

### **PR Description**
- Updated `aws-cdk` dependency from version `2.173.0` to `2.173.2` in `devDependencies` and `peerDependencies`.
- Updated `aws-cdk-lib` dependency from version `2.173.0` to `2.173.2` in `dependencies` and `peerDependencies`.
- Incremented the project version from `0.1.1` to `0.1.2` in `package.json`.

