### PR TITLE
Update AWS CDK dependencies to version 2.173.4 and increment project version


### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2024-12-29 [*][https://github.com/OpenWorkspace-o1/aws-aurora-serverless/pull/24]
+
+### Updated
+- Updated `aws-cdk` from `2.173.2` to `2.173.4` in `devDependencies` and `peerDependencies`
+- Updated `aws-cdk-lib` from `2.173.2` to `2.173.4` in `dependencies` and `peerDependencies`
+- Incremented project version from `0.1.2` to `0.1.3
+
 ## 2024-12-19
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-aurora-serverless",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-aurora-serverless",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "aws-cdk-lib": "2.173.4",
         "cdk-nag": "^2.34.23",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "aws-aurora-serverless",
       "version": "0.1.2",
       "dependencies": {
-        "aws-cdk-lib": "2.173.2",
+        "aws-cdk-lib": "2.173.4",
         "cdk-nag": "^2.34.23",
         "constructs": "^10.4.2",
         "dotenv": "^16.4.7"
@@ -21,15 +21,15 @@
         "@types/jest": "^29.5.14",
         "@types/node": "22.10.2",
         "@types/source-map-support": "^0.5.10",
-        "aws-cdk": "2.173.2",
+        "aws-cdk": "2.173.4",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
         "typescript": "~5.7.2"
       },
       "peerDependencies": {
-        "aws-cdk": "2.173.2",
-        "aws-cdk-lib": "2.173.2",
+        "aws-cdk": "2.173.4",
+        "aws-cdk-lib": "2.173.4",
         "constructs": "^10.4.2"
       }
     },
@@ -1286,9 +1286,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.173.2",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.173.2.tgz",
-      "integrity": "sha512-qyMU4FoRJdZDUpsOBqyRBALBjf5A2N/MaHKX9iJUkbTET+d+nR07x3ai4TcEES+8pqPFHMTKpQMRDXs9Py/15w==",
+      "version": "2.173.4",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.173.4.tgz",
+      "integrity": "sha512-zgs3xU28VEKIwHwJHu0ZHeoEmwLGnHS2jPCMc2MsIMZu+a7CKyE77Tw6LwJkuuB96BQyqr6xJB3SbeWjXmcFhQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1302,9 +1302,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.173.2",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.173.2.tgz",
-      "integrity": "sha512-cL9+z8Pl3VZGoO7BwdsrFAOeud/vSl3at7OvmhihbNprMN15XuFUx/rViAU5OI1m92NbV4NBzYSLbSeCwYLNyw==",
+      "version": "2.173.4",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.173.4.tgz",
+      "integrity": "sha512-0reN94TzkWmyVZDDBlYB4qzJUig8wTHEe82YLHlWRUhrU78fT+drVGUr+lYZwwETaZ+8fLdCOl9ULvFNq7iczQ==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-aurora-serverless",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "bin": {
     "aws-aurora-serverless": "bin/aws-aurora-serverless.js"
   },

--- a/package.json
+++ b/package.json
@@ -15,21 +15,21 @@
     "@types/jest": "^29.5.14",
     "@types/node": "22.10.2",
     "@types/source-map-support": "^0.5.10",
-    "aws-cdk": "2.173.2",
+    "aws-cdk": "2.173.4",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "typescript": "~5.7.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.173.2",
+    "aws-cdk-lib": "2.173.4",
     "cdk-nag": "^2.34.23",
     "constructs": "^10.4.2",
     "dotenv": "^16.4.7"
   },
   "peerDependencies": {
-    "aws-cdk": "2.173.2",
-    "aws-cdk-lib": "2.173.2",
+    "aws-cdk": "2.173.4",
+    "aws-cdk-lib": "2.173.4",
     "constructs": "^10.4.2"
   }
 }


### PR DESCRIPTION
### **PR Type**
Dependencies, Configuration

___

### **PR Description**
- Updated `aws-cdk` dependency from version `2.173.2` to `2.173.4` in `devDependencies` and `peerDependencies`.
- Updated `aws-cdk-lib` dependency from version `2.173.2` to `2.173.4` in `dependencies` and `peerDependencies`.
- Incremented the project version from `0.1.2` to `0.1.3` in `package.json`.
