### PR TITLE
Add configurable `STORAGE_TYPE` property for Aurora clusters


### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,5 @@ RDS_PASSWORD=password
 DEFAULT_DATABASE_NAME=default
 
 STORAGE_TYPE= # aurora or aurora-iopt1
+
+MONITORING_INTERVAL=1 # in minutes

--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,5 @@ RDS_USERNAME=root
 RDS_PASSWORD=password
 
 DEFAULT_DATABASE_NAME=default
+
+STORAGE_TYPE= # aurora or aurora-iopt1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 2024-12-29 [*][https://github.com/OpenWorkspace-o1/aws-aurora-serverless/pull/26]
+
+### Added
+- Introduced configurable `STORAGE_TYPE` property for Aurora clusters
+  * Added support for `AURORA` and `AURORA_IOPT1` storage types
+  * Implemented utility functions for storage type parsing and validation
+- Added `monitoringInterval` configuration for enhanced CloudWatch monitoring
+- Updated environment configuration to include `STORAGE_TYPE` and `MONITORING_INTERVAL`
+
+### Changed
+- Enhanced `AwsAuroraServerlessStack` to utilize new storage type configuration
+- Updated `.env.example` and `process-env.d.ts` to support new configuration options
+
 ## 2024-12-29 [*][https://github.com/OpenWorkspace-o1/aws-aurora-serverless/pull/24]
 
 ### Updated

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ This project provides an AWS CDK implementation for deploying an Aurora Serverle
    - `RDS_PASSWORD`: Database admin password
    - `STORAGE_TYPE`: aurora or aurora-iopt1
    - `DEFAULT_DATABASE_NAME`: Default database name
+   - `MONITORING_INTERVAL`: Monitoring interval in minutes
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ This project provides an AWS CDK implementation for deploying an Aurora Serverle
    - `SERVERLESS_V2_MIN_CAPACITY`: Minimum ACU capacity
    - `RDS_USERNAME`: Database admin username
    - `RDS_PASSWORD`: Database admin password
+   - `STORAGE_TYPE`: aurora or aurora-iopt1
+   - `DEFAULT_DATABASE_NAME`: Default database name
 
 ## Deployment
 

--- a/bin/aws-aurora-serverless.ts
+++ b/bin/aws-aurora-serverless.ts
@@ -10,6 +10,7 @@ import { Aspects } from 'aws-cdk-lib';
 import { AwsSolutionsChecks } from 'cdk-nag';
 import { AwsAuroraServerlessStack } from '../lib/aws-aurora-serverless-stack';
 import { AuroraEngine, AwsAuroraServerlessStackProps } from '../lib/AwsAuroraServerlessStackProps';
+import { parseStorageTypeFromEnv } from '../utils/storage-type-parser';
 
 dotenv.config(); // Load environment variables from .env file
 const app = new cdk.App();
@@ -32,6 +33,7 @@ checkEnvVariables('APP_NAME',
     'RDS_USERNAME',
     'RDS_PASSWORD',
     'DEFAULT_DATABASE_NAME',
+    'STORAGE_TYPE',
 );
 
 const { CDK_DEFAULT_ACCOUNT: account } = process.env;
@@ -72,6 +74,7 @@ const stackProps: AwsAuroraServerlessStackProps = {
     rdsUsername: process.env.RDS_USERNAME!,
     rdsPassword: process.env.RDS_PASSWORD!,
     defaultDatabaseName: process.env.DEFAULT_DATABASE_NAME!,
+    storageType: parseStorageTypeFromEnv(),
 };
 new AwsAuroraServerlessStack(app, `AwsAuroraServerlessStack`, {
     ...stackProps,

--- a/bin/aws-aurora-serverless.ts
+++ b/bin/aws-aurora-serverless.ts
@@ -34,6 +34,7 @@ checkEnvVariables('APP_NAME',
     'RDS_PASSWORD',
     'DEFAULT_DATABASE_NAME',
     'STORAGE_TYPE',
+    'MONITORING_INTERVAL',
 );
 
 const { CDK_DEFAULT_ACCOUNT: account } = process.env;
@@ -75,6 +76,7 @@ const stackProps: AwsAuroraServerlessStackProps = {
     rdsPassword: process.env.RDS_PASSWORD!,
     defaultDatabaseName: process.env.DEFAULT_DATABASE_NAME!,
     storageType: parseStorageTypeFromEnv(),
+    monitoringInterval: Number(process.env.MONITORING_INTERVAL!),
 };
 new AwsAuroraServerlessStack(app, `AwsAuroraServerlessStack`, {
     ...stackProps,

--- a/lib/AwsAuroraServerlessStackProps.ts
+++ b/lib/AwsAuroraServerlessStackProps.ts
@@ -17,6 +17,7 @@ export interface AwsAuroraServerlessStackProps extends StackProps {
     readonly rdsPassword: string;
     readonly defaultDatabaseName: string;
     readonly storageType: StorageType;
+    readonly monitoringInterval: number;
 }
 
 export enum AuroraEngine {

--- a/lib/AwsAuroraServerlessStackProps.ts
+++ b/lib/AwsAuroraServerlessStackProps.ts
@@ -1,5 +1,4 @@
 import { StackProps } from "aws-cdk-lib";
-
 export interface AwsAuroraServerlessStackProps extends StackProps {
     readonly resourcePrefix: string;
     readonly deployRegion: string | undefined;
@@ -17,9 +16,15 @@ export interface AwsAuroraServerlessStackProps extends StackProps {
     readonly rdsUsername: string;
     readonly rdsPassword: string;
     readonly defaultDatabaseName: string;
+    readonly storageType: StorageType;
 }
 
 export enum AuroraEngine {
     AuroraPostgresql = "aurora-postgresql",
     AuroraMysql = "aurora-mysql",
+}
+
+export enum StorageType {
+    AURORA = "aurora",
+    AURORA_IOPT1 = "aurora-iopt1",
 }

--- a/lib/aws-aurora-serverless-stack.ts
+++ b/lib/aws-aurora-serverless-stack.ts
@@ -88,7 +88,7 @@ export class AwsAuroraServerlessStack extends cdk.Stack {
       storageType: parseStorageType(props.storageType),
       backtrackWindow: props.auroraEngine === AuroraEngine.AuroraMysql ? cdk.Duration.hours(24) : undefined,
       defaultDatabaseName: props.defaultDatabaseName,
-      monitoringInterval: cdk.Duration.minutes(1),
+      monitoringInterval: cdk.Duration.minutes(props.monitoringInterval),
       cloudwatchLogsExports: ['error', 'general', 'slowquery'],
     });
 

--- a/lib/aws-aurora-serverless-stack.ts
+++ b/lib/aws-aurora-serverless-stack.ts
@@ -88,6 +88,8 @@ export class AwsAuroraServerlessStack extends cdk.Stack {
       storageType: parseStorageType(props.storageType),
       backtrackWindow: props.auroraEngine === AuroraEngine.AuroraMysql ? cdk.Duration.hours(24) : undefined,
       defaultDatabaseName: props.defaultDatabaseName,
+      monitoringInterval: cdk.Duration.minutes(1),
+      cloudwatchLogsExports: ['error', 'general', 'slowquery'],
     });
 
     // Add suppression for the deletion protection warning

--- a/lib/aws-aurora-serverless-stack.ts
+++ b/lib/aws-aurora-serverless-stack.ts
@@ -4,10 +4,11 @@ import * as rds from 'aws-cdk-lib/aws-rds';
 import * as kms from 'aws-cdk-lib/aws-kms';
 import { NagSuppressions } from 'cdk-nag';
 import { Construct } from 'constructs';
-import { AuroraEngine, AwsAuroraServerlessStackProps } from './AwsAuroraServerlessStackProps';
+import { AuroraEngine, AwsAuroraServerlessStackProps, StorageType } from './AwsAuroraServerlessStackProps';
 import { SecretValue } from 'aws-cdk-lib';
 import { parseVpcSubnetType } from '../utils/vpc-type-parser';
 import { SubnetSelection } from 'aws-cdk-lib/aws-ec2';
+import { parseStorageType } from '../utils/storage-type-parser';
 
 export class AwsAuroraServerlessStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: AwsAuroraServerlessStackProps) {
@@ -82,10 +83,10 @@ export class AwsAuroraServerlessStack extends cdk.Stack {
       iamAuthentication: true,
       backup: {
         retention: cdk.Duration.days(14),
-        preferredWindow: '03:00-04:00'
+        preferredWindow: '03:00-04:00',
       },
-      backtrackWindow: props.auroraEngine === AuroraEngine.AuroraMysql ?
-        cdk.Duration.hours(24) : undefined,
+      storageType: parseStorageType(props.storageType),
+      backtrackWindow: props.auroraEngine === AuroraEngine.AuroraMysql ? cdk.Duration.hours(24) : undefined,
       defaultDatabaseName: props.defaultDatabaseName,
     });
 

--- a/process-env.d.ts
+++ b/process-env.d.ts
@@ -16,5 +16,6 @@ declare module NodeJS {
         SERVERLESS_V2_MIN_CAPACITY: number;
         AURORA_ENGINE: string;
         DEFAULT_DATABASE_NAME: string;
+        STORAGE_TYPE: string;
     }
 }

--- a/process-env.d.ts
+++ b/process-env.d.ts
@@ -17,5 +17,6 @@ declare module NodeJS {
         AURORA_ENGINE: string;
         DEFAULT_DATABASE_NAME: string;
         STORAGE_TYPE: string;
+        MONITORING_INTERVAL: number;
     }
 }

--- a/utils/storage-type-parser.ts
+++ b/utils/storage-type-parser.ts
@@ -1,0 +1,18 @@
+import { DBClusterStorageType } from "aws-cdk-lib/aws-rds";
+import { StorageType } from "../lib/AwsAuroraServerlessStackProps";
+
+export const parseStorageType = (storageType: StorageType): DBClusterStorageType => {
+    return storageType === StorageType.AURORA_IOPT1 ? DBClusterStorageType.AURORA_IOPT1 : DBClusterStorageType.AURORA;
+}
+
+export const parseStorageTypeFromEnv = (): StorageType => {
+    const storageType = process.env.STORAGE_TYPE;
+    if (!storageType) {
+        throw new Error('STORAGE_TYPE is not set');
+    }
+    const acceptedValues = [StorageType.AURORA, StorageType.AURORA_IOPT1];
+    if (!acceptedValues.includes(storageType as StorageType)) {
+        throw new Error(`Invalid STORAGE_TYPE value: ${storageType}`);
+    }
+    return storageType as StorageType;
+}

--- a/utils/storage-type-parser.ts
+++ b/utils/storage-type-parser.ts
@@ -10,9 +10,10 @@ export const parseStorageTypeFromEnv = (): StorageType => {
     if (!storageType) {
         throw new Error('STORAGE_TYPE is not set');
     }
+    const storageTypeUpper = storageType.toUpperCase();
     const acceptedValues = [StorageType.AURORA, StorageType.AURORA_IOPT1];
-    if (!acceptedValues.includes(storageType as StorageType)) {
-        throw new Error(`Invalid STORAGE_TYPE value: ${storageType}`);
+    if (!acceptedValues.includes(storageTypeUpper as StorageType)) {
+        throw new Error(`Invalid STORAGE_TYPE value: ${storageType}. Must be one of: ${acceptedValues.join(', ')}`);
     }
     return storageType as StorageType;
 }


### PR DESCRIPTION
### **PR Type**
Feature, Documentation

___

### **PR Description**
- Introduced a new configurable property `STORAGE_TYPE` to define the storage type for Aurora clusters.
- Added a new `StorageType` enum in `AwsAuroraServerlessStackProps` to support `AURORA` and `AURORA_IOPT1` storage types.
- Implemented utility functions `parseStorageType` and `parseStorageTypeFromEnv` to handle storage type parsing and validation.
- Updated the `AwsAuroraServerlessStack` to utilize the `STORAGE_TYPE` property for configuring the Aurora cluster's storage type.
- Enhanced `.env.example` and `process-env.d.ts` to include the `STORAGE_TYPE` environment variable.
- Updated the README file to document the new `STORAGE_TYPE` property.
