### PR TITLE
Add support for CLUSTER_SCALABILITY_TYPE in AWS Aurora Serverless CDK stack


### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -10,7 +10,7 @@ VPC_PRIVATE_SUBNET_IDS=subnet-xxxxxxxx,subnet-xxxxxxxx,subnet-xxxxxxxx
 VPC_PRIVATE_SUBNET_AZS=ap-southeast-1a,ap-southeast-1b,ap-southeast-1c
 VPC_PRIVATE_SUBNET_ROUTE_TABLE_IDS=rtb-xxxxxxxx,rtb-xxxxxxxx,rtb-xxxxxxxx
 
-AURORA_ENGINE= # aurora-postgresql or aurora-mysql
+AURORA_ENGINE=aurora-postgresql
 SERVERLESS_V2_MAX_CAPACITY=2
 SERVERLESS_V2_MIN_CAPACITY=0
 
@@ -19,8 +19,8 @@ RDS_PASSWORD=password
 
 DEFAULT_DATABASE_NAME=default
 
-STORAGE_TYPE= # aurora or aurora-iopt1
+STORAGE_TYPE=aurora-iopt1
 
-MONITORING_INTERVAL=1 # in minutes
+MONITORING_INTERVAL=60
 
-CLUSTER_SCALABILITY_TYPE= # standard or limitless
+CLUSTER_SCALABILITY_TYPE=limitless

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ This project provides an AWS CDK implementation for deploying an Aurora Serverle
    - `STORAGE_TYPE`: aurora or aurora-iopt1
    - `DEFAULT_DATABASE_NAME`: Default database name
    - `MONITORING_INTERVAL`: Monitoring interval in minutes
+   - `CLUSTER_SCALABILITY_TYPE`: standard or limitless
 
 ## Deployment
 

--- a/bin/aws-aurora-serverless.ts
+++ b/bin/aws-aurora-serverless.ts
@@ -11,6 +11,7 @@ import { AwsSolutionsChecks } from 'cdk-nag';
 import { AwsAuroraServerlessStack } from '../lib/aws-aurora-serverless-stack';
 import { AuroraEngine, AwsAuroraServerlessStackProps } from '../lib/AwsAuroraServerlessStackProps';
 import { parseStorageTypeFromEnv } from '../utils/storage-type-parser';
+import { parseClusterScailabilityTypeFromEnv } from '../utils/cluster-scailability-parser';
 
 dotenv.config(); // Load environment variables from .env file
 const app = new cdk.App();
@@ -35,6 +36,7 @@ checkEnvVariables('APP_NAME',
     'DEFAULT_DATABASE_NAME',
     'STORAGE_TYPE',
     'MONITORING_INTERVAL',
+    'CLUSTER_SCALABILITY_TYPE',
 );
 
 const { CDK_DEFAULT_ACCOUNT: account } = process.env;
@@ -77,6 +79,7 @@ const stackProps: AwsAuroraServerlessStackProps = {
     defaultDatabaseName: process.env.DEFAULT_DATABASE_NAME!,
     storageType: parseStorageTypeFromEnv(),
     monitoringInterval: Number(process.env.MONITORING_INTERVAL!),
+    clusterScailabilityType: parseClusterScailabilityTypeFromEnv(),
 };
 new AwsAuroraServerlessStack(app, `AwsAuroraServerlessStack`, {
     ...stackProps,

--- a/lib/AwsAuroraServerlessStackProps.ts
+++ b/lib/AwsAuroraServerlessStackProps.ts
@@ -1,4 +1,5 @@
 import { StackProps } from "aws-cdk-lib";
+import { ClusterScailabilityType } from "aws-cdk-lib/aws-rds";
 export interface AwsAuroraServerlessStackProps extends StackProps {
     readonly resourcePrefix: string;
     readonly deployRegion: string | undefined;
@@ -18,6 +19,7 @@ export interface AwsAuroraServerlessStackProps extends StackProps {
     readonly defaultDatabaseName: string;
     readonly storageType: StorageType;
     readonly monitoringInterval: number;
+    readonly clusterScailabilityType: ClusterScailabilityType;
 }
 
 export enum AuroraEngine {

--- a/lib/aws-aurora-serverless-stack.ts
+++ b/lib/aws-aurora-serverless-stack.ts
@@ -90,6 +90,7 @@ export class AwsAuroraServerlessStack extends cdk.Stack {
       defaultDatabaseName: props.defaultDatabaseName,
       monitoringInterval: cdk.Duration.minutes(props.monitoringInterval),
       cloudwatchLogsExports: ['error', 'general', 'slowquery'],
+      clusterScailabilityType: props.clusterScailabilityType,
     });
 
     // Add suppression for the deletion protection warning

--- a/process-env.d.ts
+++ b/process-env.d.ts
@@ -18,5 +18,6 @@ declare module NodeJS {
         DEFAULT_DATABASE_NAME: string;
         STORAGE_TYPE: string;
         MONITORING_INTERVAL: number;
+        CLUSTER_SCALABILITY_TYPE: string;
     }
 }

--- a/utils/cluster-scailability-parser.ts
+++ b/utils/cluster-scailability-parser.ts
@@ -1,0 +1,14 @@
+import { ClusterScailabilityType } from "aws-cdk-lib/aws-rds";
+
+export const parseClusterScailabilityTypeFromEnv = (): ClusterScailabilityType => {
+    const clusterScailabilityType = process.env.CLUSTER_SCALABILITY_TYPE;
+    if (!clusterScailabilityType) {
+        throw new Error('CLUSTER_SCALABILITY_TYPE is not set');
+    }
+    const clusterScailabilityTypeUpper = clusterScailabilityType.toUpperCase();
+    const acceptedValues = [ClusterScailabilityType.STANDARD, ClusterScailabilityType.LIMITLESS];
+    if (!acceptedValues.includes(clusterScailabilityTypeUpper as ClusterScailabilityType)) {
+        throw new Error(`Invalid CLUSTER_SCALABILITY_TYPE value: ${clusterScailabilityType}. Must be one of: ${acceptedValues.join(', ')}`);
+    }
+    return clusterScailabilityTypeUpper as ClusterScailabilityType;
+}

--- a/utils/storage-type-parser.ts
+++ b/utils/storage-type-parser.ts
@@ -15,5 +15,5 @@ export const parseStorageTypeFromEnv = (): StorageType => {
     if (!acceptedValues.includes(storageTypeUpper as StorageType)) {
         throw new Error(`Invalid STORAGE_TYPE value: ${storageType}. Must be one of: ${acceptedValues.join(', ')}`);
     }
-    return storageType as StorageType;
+    return storageTypeUpper as StorageType;
 }


### PR DESCRIPTION
### **PR Type**
Feature, Configuration

___

### **PR Description**
- Introduced support for `CLUSTER_SCALABILITY_TYPE` in the AWS Aurora Serverless CDK stack.
- Added a new utility function `parseClusterScailabilityTypeFromEnv` to validate and parse the `CLUSTER_SCALABILITY_TYPE` environment variable.
- Updated the `AwsAuroraServerlessStackProps` interface to include the `clusterScailabilityType` property.
- Modified the `AwsAuroraServerlessStack` class to utilize the `clusterScailabilityType` property when configuring the Aurora database cluster.
- Enhanced `.env.example` and added a new `.env.production.example` file to document and provide examples for the `CLUSTER_SCALABILITY_TYPE` variable.
- Improved error handling in `parseStorageTypeFromEnv` by ensuring the returned value is uppercase.
