### PR TITLE
Enable automatic KMS key rotation every 30 days in AWS Aurora Serverless stack


### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2024-12-31 [*][https://github.com/OpenWorkspace-o1/aws-aurora-serverless/pull/33]
+
+### Changed
+- Enabled automatic KMS key rotation every 30 days
+- Explicitly enabled KMS key with `enabled: true` property
+- Reordered KMS key configuration properties for improved clarity and consistency
+
 ## 2024-12-29 [*][https://github.com/OpenWorkspace-o1/aws-aurora-serverless/pull/26]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -68,16 +68,16 @@ This project provides an AWS CDK implementation for deploying an Aurora Serverle
    - `ENVIRONMENT`: Deployment environment (development/staging/production)
    - `OWNER`: Owner tag value
    - `VPC_ID`: Target VPC ID
-   - `VPC_SUBNET_TYPE`: PRIVATE_WITH_EGRESS, PRIVATE_ISOLATED, or PUBLIC
-   - `AURORA_ENGINE`: aurora-postgresql or aurora-mysql
+   - `VPC_SUBNET_TYPE`: `PRIVATE_WITH_EGRESS`, `PRIVATE_ISOLATED`, or `PUBLIC`
+   - `AURORA_ENGINE`: `aurora-postgresql` or `aurora-mysql`
    - `SERVERLESS_V2_MAX_CAPACITY`: Maximum ACU capacity
    - `SERVERLESS_V2_MIN_CAPACITY`: Minimum ACU capacity
    - `RDS_USERNAME`: Database admin username
    - `RDS_PASSWORD`: Database admin password
-   - `STORAGE_TYPE`: aurora or aurora-iopt1
+   - `STORAGE_TYPE`: `aurora` or `aurora-iopt1`
    - `DEFAULT_DATABASE_NAME`: Default database name
    - `MONITORING_INTERVAL`: Monitoring interval in minutes
-   - `CLUSTER_SCALABILITY_TYPE`: standard or limitless
+   - `CLUSTER_SCALABILITY_TYPE`: `standard` or `limitless`
 
 ## Deployment
 

--- a/lib/aws-aurora-serverless-stack.ts
+++ b/lib/aws-aurora-serverless-stack.ts
@@ -44,9 +44,10 @@ export class AwsAuroraServerlessStack extends cdk.Stack {
     });
 
     const kmsKey = new kms.Key(this, `${props.resourcePrefix}-Aurora-KMS-Key`, {
-      enableKeyRotation: true,
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
       enabled: true,
+      enableKeyRotation: true,
+      rotationPeriod: cdk.Duration.days(30),
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
       keyUsage: kms.KeyUsage.ENCRYPT_DECRYPT,
       keySpec: kms.KeySpec.SYMMETRIC_DEFAULT,
     });


### PR DESCRIPTION
### **PR Type**
Enhancement, Configuration

___

### **PR Description**
- Enabled automatic rotation of the KMS key every 30 days by adding the `rotationPeriod` property to the KMS key configuration.
- Ensured the KMS key is explicitly enabled by adding the `enabled` property.
- Adjusted the order of properties in the KMS key configuration for clarity and consistency.
