### PR TITLE
Init cdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2025-01-11 [*][https://github.com/OpenWorkspace-o1/aws-aurora-serverless/pull/37]
+
+### Changed
+- Replaced custom `StorageType` enum with `DBClusterStorageType` for improved consistency and simplicity.
+- Simplified `parseStorageTypeFromEnv` to directly use `DBClusterStorageType`.
+- Updated `AwsAuroraServerlessStackProps` to utilize `DBClusterStorageType`.
+
+### Updated
+- Updated `aws-cdk` and `aws-cdk-lib` dependencies from `2.175.0` to `2.175.1`.
+- Incremented project version from `0.1.4` to `0.1.5` in `package.json`.
+
 ## 2025-01-10 [*][https://github.com/OpenWorkspace-o1/aws-aurora-serverless/pull/35]
 
 ### Updated

--- a/lib/AwsAuroraServerlessStackProps.ts
+++ b/lib/AwsAuroraServerlessStackProps.ts
@@ -1,5 +1,5 @@
 import { StackProps } from "aws-cdk-lib";
-import { ClusterScailabilityType } from "aws-cdk-lib/aws-rds";
+import { ClusterScailabilityType, DBClusterStorageType } from "aws-cdk-lib/aws-rds";
 
 export interface AwsAuroraServerlessStackProps extends StackProps {
     /** Resource prefix for all AWS resources */
@@ -35,7 +35,7 @@ export interface AwsAuroraServerlessStackProps extends StackProps {
     /** Name of the default database to be created */
     readonly defaultDatabaseName: string;
     /** Storage type for the Aurora cluster */
-    readonly storageType: StorageType;
+    readonly storageType: DBClusterStorageType;
     /** Enhanced monitoring interval in minutes */
     readonly monitoringInterval: number;
     /** Type of cluster scalability configuration */
@@ -48,12 +48,4 @@ export enum AuroraEngine {
     AuroraPostgresql = "aurora-postgresql",
     /** MySQL-compatible Aurora engine */
     AuroraMysql = "aurora-mysql",
-}
-
-/** Available storage types for Aurora clusters */
-export enum StorageType {
-    /** Standard Aurora storage */
-    AURORA = "aurora",
-    /** I/O optimized Aurora storage */
-    AURORA_IOPT1 = "aurora-iopt1",
 }

--- a/lib/aws-aurora-serverless-stack.ts
+++ b/lib/aws-aurora-serverless-stack.ts
@@ -4,11 +4,10 @@ import * as rds from 'aws-cdk-lib/aws-rds';
 import * as kms from 'aws-cdk-lib/aws-kms';
 import { NagSuppressions } from 'cdk-nag';
 import { Construct } from 'constructs';
-import { AuroraEngine, AwsAuroraServerlessStackProps, StorageType } from './AwsAuroraServerlessStackProps';
+import { AuroraEngine, AwsAuroraServerlessStackProps } from './AwsAuroraServerlessStackProps';
 import { SecretValue } from 'aws-cdk-lib';
 import { parseVpcSubnetType } from '../utils/vpc-type-parser';
 import { SubnetSelection } from 'aws-cdk-lib/aws-ec2';
-import { parseStorageType } from '../utils/storage-type-parser';
 
 export class AwsAuroraServerlessStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: AwsAuroraServerlessStackProps) {
@@ -86,7 +85,7 @@ export class AwsAuroraServerlessStack extends cdk.Stack {
         retention: cdk.Duration.days(14),
         preferredWindow: '03:00-04:00',
       },
-      storageType: parseStorageType(props.storageType),
+      storageType: props.storageType,
       backtrackWindow: props.auroraEngine === AuroraEngine.AuroraMysql ? cdk.Duration.hours(24) : undefined,
       defaultDatabaseName: props.defaultDatabaseName,
       monitoringInterval: cdk.Duration.minutes(props.monitoringInterval),

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "aws-aurora-serverless",
       "version": "0.1.4",
       "dependencies": {
-        "aws-cdk-lib": "2.175.0",
+        "aws-cdk-lib": "2.175.1",
         "cdk-nag": "^2.34.23",
         "constructs": "^10.4.2",
         "dotenv": "^16.4.7"
@@ -21,15 +21,15 @@
         "@types/jest": "^29.5.14",
         "@types/node": "22.10.5",
         "@types/source-map-support": "^0.5.10",
-        "aws-cdk": "2.175.0",
+        "aws-cdk": "2.175.1",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
-        "typescript": "~5.7.2"
+        "typescript": "~5.7.3"
       },
       "peerDependencies": {
-        "aws-cdk": "2.175.0",
-        "aws-cdk-lib": "2.175.0",
+        "aws-cdk": "2.175.1",
+        "aws-cdk-lib": "2.175.1",
         "constructs": "^10.4.2"
       }
     },
@@ -1286,9 +1286,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.175.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.175.0.tgz",
-      "integrity": "sha512-vWMI/DRicvqH+yfOE0ykZolZwn/U9oRvpt1GyoNx1USS/NWc/60Pico9zx8Ui6fc1fYK3ow+Gwl3p/Cch9uscQ==",
+      "version": "2.175.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.175.1.tgz",
+      "integrity": "sha512-duvy0FtGAAYqJi/x0MjBfCp60ZlDYl0X5/GrADwMz4AfHQ8aTXCyaVsdJuCxz0ZMHSNaFRuCNkAlc2Xu43zQmQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1302,9 +1302,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.175.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.175.0.tgz",
-      "integrity": "sha512-QZddiS+kFv7SuQtBTUHscO8BHhd3v3BOLMSe1tMR8dE7XvPhY50p6Amqdo4pI6lZqAJma1wC2SZkHmajzTzgVQ==",
+      "version": "2.175.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.175.1.tgz",
+      "integrity": "sha512-2OiZDUeuAA5nBrWKxQVT0CHrQmLLx7SIpUeqyKRLEdiYPFlj3nCd/0KcVpsy6hPKS+IZp7Qm1kghmGMsV6JGoA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -4267,9 +4267,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-aurora-serverless",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-aurora-serverless",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "aws-cdk-lib": "2.175.1",
         "cdk-nag": "^2.34.23",

--- a/package.json
+++ b/package.json
@@ -15,21 +15,21 @@
     "@types/jest": "^29.5.14",
     "@types/node": "22.10.5",
     "@types/source-map-support": "^0.5.10",
-    "aws-cdk": "2.175.0",
+    "aws-cdk": "2.175.1",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
-    "typescript": "~5.7.2"
+    "typescript": "~5.7.3"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.175.0",
+    "aws-cdk-lib": "2.175.1",
     "cdk-nag": "^2.34.23",
     "constructs": "^10.4.2",
     "dotenv": "^16.4.7"
   },
   "peerDependencies": {
-    "aws-cdk": "2.175.0",
-    "aws-cdk-lib": "2.175.0",
+    "aws-cdk": "2.175.1",
+    "aws-cdk-lib": "2.175.1",
     "constructs": "^10.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-aurora-serverless",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "bin": {
     "aws-aurora-serverless": "bin/aws-aurora-serverless.js"
   },

--- a/utils/storage-type-parser.ts
+++ b/utils/storage-type-parser.ts
@@ -1,19 +1,14 @@
 import { DBClusterStorageType } from "aws-cdk-lib/aws-rds";
-import { StorageType } from "../lib/AwsAuroraServerlessStackProps";
 
-export const parseStorageType = (storageType: StorageType): DBClusterStorageType => {
-    return storageType === StorageType.AURORA_IOPT1 ? DBClusterStorageType.AURORA_IOPT1 : DBClusterStorageType.AURORA;
-}
-
-export const parseStorageTypeFromEnv = (): StorageType => {
+export const parseStorageTypeFromEnv = (): DBClusterStorageType => {
     const storageType = process.env.STORAGE_TYPE;
     if (!storageType) {
         throw new Error('STORAGE_TYPE is not set');
     }
     const storageTypeUpper = storageType.toUpperCase();
-    const acceptedValues = [StorageType.AURORA, StorageType.AURORA_IOPT1];
-    if (!acceptedValues.includes(storageTypeUpper as StorageType)) {
+    const acceptedValues = [DBClusterStorageType.AURORA, DBClusterStorageType.AURORA_IOPT1];
+    if (!acceptedValues.includes(storageTypeUpper as DBClusterStorageType)) {
         throw new Error(`Invalid STORAGE_TYPE value: ${storageType}. Must be one of: ${acceptedValues.join(', ')}`);
     }
-    return storageTypeUpper as StorageType;
+    return storageTypeUpper as DBClusterStorageType;
 }


### PR DESCRIPTION
### **PR Type**
Enhancement, Dependencies

___

### **PR Description**
- Replaced custom `StorageType` enum with `DBClusterStorageType`.
  - Simplified `parseStorageTypeFromEnv` to use `DBClusterStorageType`.
  - Removed `StorageType` enum and related parsing logic.

- Updated `AwsAuroraServerlessStackProps` to use `DBClusterStorageType`.

- Updated `aws-cdk` and `aws-cdk-lib` dependencies from `2.175.0` to `2.175.1`.

- Incremented project version from `0.1.4` to `0.1.5` in `package.json`.
