### PR TITLE
Init cdk

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,6 @@ DEFAULT_DATABASE_NAME=default
 
 STORAGE_TYPE=aurora # aurora or aurora-iopt1
 
-MONITORING_INTERVAL=60 # in minutes
+MONITORING_INTERVAL=60 # in seconds
 
 CLUSTER_SCALABILITY_TYPE=standard # standard or limitless

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2025-01-16 [*][https://github.com/OpenWorkspace-o1/aws-aurora-serverless/pull/43]
+
+### Changed
+- Updated KMS key rotation period from `30` to `90` days.
+- Changed `MONITORING_INTERVAL` unit from minutes to seconds.
+- Improved parsing logic for `STORAGE_TYPE` and `CLUSTER_SCALABILITY_TYPE` to use lowercase comparison.
+
+### Removed
+- Removed `cloudwatchLogsExports` from Aurora database cluster configuration.
+
 ## 2025-01-16 [*][https://github.com/OpenWorkspace-o1/aws-aurora-serverless/pull/41]
 
 ### Fixed

--- a/lib/aws-aurora-serverless-stack.ts
+++ b/lib/aws-aurora-serverless-stack.ts
@@ -45,7 +45,7 @@ export class AwsAuroraServerlessStack extends cdk.Stack {
     const kmsKey = new kms.Key(this, `${props.resourcePrefix}-Aurora-KMS-Key`, {
       enabled: true,
       enableKeyRotation: true,
-      rotationPeriod: cdk.Duration.days(30),
+      rotationPeriod: cdk.Duration.days(90),
       removalPolicy: cdk.RemovalPolicy.DESTROY,
       keyUsage: kms.KeyUsage.ENCRYPT_DECRYPT,
       keySpec: kms.KeySpec.SYMMETRIC_DEFAULT,
@@ -88,8 +88,7 @@ export class AwsAuroraServerlessStack extends cdk.Stack {
       storageType: props.storageType,
       backtrackWindow: props.auroraEngine === AuroraEngine.AuroraMysql ? cdk.Duration.hours(24) : undefined,
       defaultDatabaseName: props.defaultDatabaseName,
-      monitoringInterval: cdk.Duration.minutes(props.monitoringInterval),
-      cloudwatchLogsExports: ['error', 'general', 'slowquery'],
+      monitoringInterval: cdk.Duration.seconds(props.monitoringInterval),
       clusterScalabilityType: props.clusterScalabilityType,
     });
 

--- a/utils/cluster-scalability-parser.ts
+++ b/utils/cluster-scalability-parser.ts
@@ -5,10 +5,10 @@ export const parseClusterScalabilityTypeFromEnv = (): ClusterScalabilityType => 
     if (!clusterScalabilityType) {
         throw new Error('CLUSTER_SCALABILITY_TYPE is not set');
     }
-    const clusterScalabilityTypeUpper = clusterScalabilityType.toUpperCase();
-    const acceptedValues = [ClusterScalabilityType.STANDARD, ClusterScalabilityType.LIMITLESS];
-    if (!acceptedValues.includes(clusterScalabilityTypeUpper as ClusterScalabilityType)) {
+    const clusterScalabilityTypeLower = clusterScalabilityType.toLowerCase();
+    const acceptedValues = [ClusterScalabilityType.STANDARD.toString(), ClusterScalabilityType.LIMITLESS.toString()];
+    if (!acceptedValues.includes(clusterScalabilityTypeLower)) {
         throw new Error(`Invalid CLUSTER_SCALABILITY_TYPE value: ${clusterScalabilityType}. Must be one of: ${acceptedValues.join(', ')}`);
     }
-    return clusterScalabilityTypeUpper as ClusterScalabilityType;
+    return clusterScalabilityTypeLower === ClusterScalabilityType.STANDARD.toString() ? ClusterScalabilityType.STANDARD : ClusterScalabilityType.LIMITLESS;
 }

--- a/utils/storage-type-parser.ts
+++ b/utils/storage-type-parser.ts
@@ -5,10 +5,10 @@ export const parseStorageTypeFromEnv = (): DBClusterStorageType => {
     if (!storageType) {
         throw new Error('STORAGE_TYPE is not set');
     }
-    const storageTypeUpper = storageType.toUpperCase();
-    const acceptedValues = [DBClusterStorageType.AURORA, DBClusterStorageType.AURORA_IOPT1];
-    if (!acceptedValues.includes(storageTypeUpper as DBClusterStorageType)) {
+    const storageTypeLower = storageType.toLowerCase();
+    const acceptedValues = [DBClusterStorageType.AURORA.toString(), DBClusterStorageType.AURORA_IOPT1.toString()];
+    if (!acceptedValues.includes(storageTypeLower)) {
         throw new Error(`Invalid STORAGE_TYPE value: ${storageType}. Must be one of: ${acceptedValues.join(', ')}`);
     }
-    return storageTypeUpper as DBClusterStorageType;
+    return storageTypeLower === DBClusterStorageType.AURORA.toString() ? DBClusterStorageType.AURORA : DBClusterStorageType.AURORA_IOPT1;
 }


### PR DESCRIPTION
### **PR Type**
Enhancement, Configuration

___

### **PR Description**
- Updated KMS key rotation period from `30` to `90` days.

- Changed `MONITORING_INTERVAL` unit from minutes to seconds.

- Improved parsing logic for `STORAGE_TYPE` and `CLUSTER_SCALABILITY_TYPE` to use lowercase comparison.

- Removed `cloudwatchLogsExports` from Aurora database cluster configuration.
