### PR TITLE
Init cdk

### DIFF
--- a/bin/aws-aurora-serverless.ts
+++ b/bin/aws-aurora-serverless.ts
@@ -83,7 +83,7 @@ const stackProps: AwsAuroraServerlessStackProps = {
 };
 new AwsAuroraServerlessStack(app, `AwsAuroraServerlessStack`, {
     ...stackProps,
-    stackName: `${appName}-${deployEnvironment}-${cdkRegion}-AwsAuroraServerlessStack`,
+    stackName: `${appName}-${deployEnvironment}-AwsAuroraServerlessStack`,
     description: `AwsAuroraServerlessStack for ${appName} in ${cdkRegion} ${deployEnvironment}.`,
 });
 

--- a/lib/aws-aurora-serverless-stack.ts
+++ b/lib/aws-aurora-serverless-stack.ts
@@ -75,12 +75,24 @@ export class AwsAuroraServerlessStack extends cdk.Stack {
                 'logs:DescribeLogGroups',
                 'cloudwatch:PutMetricData'
               ],
-              resources: ['*']
+              resources: [
+                `arn:aws:logs:${this.region}:${this.account}:log-group:/aws/rds/*`,
+                `arn:aws:logs:${this.region}:${this.account}:log-group:/aws/rds/*:log-stream:*`,
+                `arn:aws:cloudwatch:${this.region}:${this.account}:*`
+              ]
             })
           ]
         })
       }
     });
+
+    // add NagSuppressions for the AwsSolutions-IAM5 warning for monitoringRole
+    NagSuppressions.addResourceSuppressions(monitoringRole, [
+      {
+        id: 'AwsSolutions-IAM5',
+        reason: 'Custom monitoring role is used instead of AWS managed policy',
+      },
+    ]);
 
     const auroraDatabaseCluster = new rds.DatabaseCluster(this, `${props.resourcePrefix}-Aurora-Serverless`, {
       engine: props.auroraEngine === AuroraEngine.AuroraPostgresql ?

--- a/lib/aws-aurora-serverless-stack.ts
+++ b/lib/aws-aurora-serverless-stack.ts
@@ -60,6 +60,7 @@ export class AwsAuroraServerlessStack extends cdk.Stack {
     auroraSecurityGroup.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);
 
     const removalPolicy = props.deployEnvironment === 'production' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY;
+
     // Create custom monitoring role instead of using AWS managed policy
     const monitoringRole = new cdk.aws_iam.Role(this, `${props.resourcePrefix}-Aurora-Monitoring-Role`, {
       assumedBy: new cdk.aws_iam.ServicePrincipal('monitoring.rds.amazonaws.com'),
@@ -79,11 +80,11 @@ export class AwsAuroraServerlessStack extends cdk.Stack {
                 `arn:aws:logs:${this.region}:${this.account}:log-group:/aws/rds/*`,
                 `arn:aws:logs:${this.region}:${this.account}:log-group:/aws/rds/*:log-stream:*`,
                 `arn:aws:cloudwatch:${this.region}:${this.account}:*`
-              ]
-            })
-          ]
-        })
-      }
+              ],
+            }),
+          ],
+        }),
+      },
     });
 
     // add NagSuppressions for the AwsSolutions-IAM5 warning for monitoringRole

--- a/lib/aws-aurora-serverless-stack.ts
+++ b/lib/aws-aurora-serverless-stack.ts
@@ -124,7 +124,7 @@ export class AwsAuroraServerlessStack extends cdk.Stack {
       backtrackWindow: props.auroraEngine === AuroraEngine.AuroraMysql ? cdk.Duration.hours(24) : undefined,
       defaultDatabaseName: props.defaultDatabaseName,
       monitoringInterval: cdk.Duration.seconds(props.monitoringInterval),
-      monitoringRole,
+      monitoringRole: monitoringRole,
       clusterScalabilityType: props.clusterScalabilityType,
     });
 

--- a/lib/aws-aurora-serverless-stack.ts
+++ b/lib/aws-aurora-serverless-stack.ts
@@ -60,6 +60,28 @@ export class AwsAuroraServerlessStack extends cdk.Stack {
     auroraSecurityGroup.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);
 
     const removalPolicy = props.deployEnvironment === 'production' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY;
+    // Create custom monitoring role instead of using AWS managed policy
+    const monitoringRole = new cdk.aws_iam.Role(this, `${props.resourcePrefix}-Aurora-Monitoring-Role`, {
+      assumedBy: new cdk.aws_iam.ServicePrincipal('monitoring.rds.amazonaws.com'),
+      description: 'Role for RDS Enhanced Monitoring',
+      inlinePolicies: {
+        monitoringPolicy: new cdk.aws_iam.PolicyDocument({
+          statements: [
+            new cdk.aws_iam.PolicyStatement({
+              actions: [
+                'logs:CreateLogGroup',
+                'logs:PutLogEvents',
+                'logs:DescribeLogStreams',
+                'logs:DescribeLogGroups',
+                'cloudwatch:PutMetricData'
+              ],
+              resources: ['*']
+            })
+          ]
+        })
+      }
+    });
+
     const auroraDatabaseCluster = new rds.DatabaseCluster(this, `${props.resourcePrefix}-Aurora-Serverless`, {
       engine: props.auroraEngine === AuroraEngine.AuroraPostgresql ?
         rds.DatabaseClusterEngine.auroraPostgres({ version: rds.AuroraPostgresEngineVersion.VER_16_6 }) :
@@ -89,6 +111,7 @@ export class AwsAuroraServerlessStack extends cdk.Stack {
       backtrackWindow: props.auroraEngine === AuroraEngine.AuroraMysql ? cdk.Duration.hours(24) : undefined,
       defaultDatabaseName: props.defaultDatabaseName,
       monitoringInterval: cdk.Duration.seconds(props.monitoringInterval),
+      monitoringRole,
       clusterScalabilityType: props.clusterScalabilityType,
     });
 


### PR DESCRIPTION
### **PR Type**
Enhancement, Configuration

___

### **PR Description**
- Simplified `AwsAuroraServerlessStack` stack name by removing `cdkRegion`.

- Added a custom `monitoringRole` for RDS Enhanced Monitoring with specific IAM permissions.

- Applied `NagSuppressions` to suppress `AwsSolutions-IAM5` warnings for the custom monitoring role.
