### PR TITLE
Support aurora VER_16_6_LIMITLESS engine version

### DIFF
--- a/lib/aws-aurora-serverless-stack.ts
+++ b/lib/aws-aurora-serverless-stack.ts
@@ -103,9 +103,12 @@ export class AwsAuroraServerlessStack extends cdk.Stack {
     ]);
 
     const removalPolicy = props.deployEnvironment === 'production' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY;
-    const auroraDatabaseCluster = new rds.DatabaseCluster(this, `${props.resourcePrefix}-Aurora-Serverless`, {
+    const auroraPostgresEngineVersion = props.clusterScalabilityType === rds.ClusterScalabilityType.LIMITLESS
+      ? rds.AuroraPostgresEngineVersion.VER_16_6_LIMITLESS
+      : rds.AuroraPostgresEngineVersion.VER_16_6;
+    const auroraDatabaseCluster = new rds.DatabaseCluster(this, `${props.resourcePrefix}-aurora-serverless-cluster`, {
       engine: props.auroraEngine === AuroraEngine.AuroraPostgresql ?
-        rds.DatabaseClusterEngine.auroraPostgres({ version: rds.AuroraPostgresEngineVersion.VER_16_6 }) :
+        rds.DatabaseClusterEngine.auroraPostgres({ version: auroraPostgresEngineVersion }) :
         rds.DatabaseClusterEngine.auroraMysql({ version: rds.AuroraMysqlEngineVersion.VER_3_08_0 }),
       vpc,
       vpcSubnets: vpcSubnetSelection,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-aurora-serverless",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-aurora-serverless",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "aws-cdk-lib": "2.178.0",
         "cdk-nag": "^2.35.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "aws-aurora-serverless",
       "version": "0.1.8",
       "dependencies": {
-        "aws-cdk-lib": "2.177.0",
-        "cdk-nag": "^2.35.9",
+        "aws-cdk-lib": "2.178.0",
+        "cdk-nag": "^2.35.11",
         "constructs": "^10.4.2",
         "dotenv": "^16.4.7"
       },
@@ -21,15 +21,15 @@
         "@types/jest": "^29.5.14",
         "@types/node": "22.13.1",
         "@types/source-map-support": "^0.5.10",
-        "aws-cdk": "2.177.0",
+        "aws-cdk": "2.178.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
         "typescript": "~5.7.3"
       },
       "peerDependencies": {
-        "aws-cdk": "2.177.0",
-        "aws-cdk-lib": "2.177.0",
+        "aws-cdk": "2.178.0",
+        "aws-cdk-lib": "2.178.0",
         "constructs": "^10.4.2"
       }
     },
@@ -1286,9 +1286,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.177.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.177.0.tgz",
-      "integrity": "sha512-TiBoyE5wMB5q4jX1bELwkklgbs5eLY1Phjfnb4Mof0K9tOSRJ9UEq6xEamF0esMS+TuYU7a/ESTpmKX3iYqA3w==",
+      "version": "2.178.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.178.0.tgz",
+      "integrity": "sha512-FcAByh9/HCgxEFE05434t+coYhOZSp92au77VSudBXhdgBrGPG28j1zSJY0XGPcH6eQxWaMWhSI6RzFK34R8MA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1302,9 +1302,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.177.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.177.0.tgz",
-      "integrity": "sha512-nTnHAwjZaPJ5gfJjtzE/MyK6q0a66nWthoJl7l8srucRb+I30dczhbbXor6QCdVpJaTRAEliMOMq23aglsAQbg==",
+      "version": "2.178.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.178.0.tgz",
+      "integrity": "sha512-rk0nmSa6uO1k15wH/je3yHup+oW5p0MMPGL9edSf4IG8YZbwAOrFYcQ6CtXieW2ags2JLtUThbqIxOIQWWQaaw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1447,12 +1447,22 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.0.3",
+      "version": "3.0.6",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
       "inBundle": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.2.0",
+      "version": "11.3.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1502,7 +1512,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/jsonschema": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1612,7 +1622,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/table": {
-      "version": "6.8.2",
+      "version": "6.9.0",
       "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1894,9 +1904,9 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/cdk-nag": {
-      "version": "2.35.9",
-      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.35.9.tgz",
-      "integrity": "sha512-owDariB1woFGADKRkDF8UShpENXkVTzcTBqMnEnjzpCNigyYZsIv6EoO/7U8CkNq6/a+UYJeKGlpezFuD5++Ew==",
+      "version": "2.35.11",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.35.11.tgz",
+      "integrity": "sha512-SDlofc+MllD0b2tZmv/ABxwQLTFNn4mXxcyUQLsVLR1nDEYUsr95Ei/29oUeqFLrgVU15hrg0eVIFAz3vP5Bqg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "aws-cdk-lib": "^2.156.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-aurora-serverless",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "bin": {
     "aws-aurora-serverless": "bin/aws-aurora-serverless.js"
   },

--- a/package.json
+++ b/package.json
@@ -15,21 +15,21 @@
     "@types/jest": "^29.5.14",
     "@types/node": "22.13.1",
     "@types/source-map-support": "^0.5.10",
-    "aws-cdk": "2.177.0",
+    "aws-cdk": "2.178.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "typescript": "~5.7.3"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.177.0",
-    "cdk-nag": "^2.35.9",
+    "aws-cdk-lib": "2.178.0",
+    "cdk-nag": "^2.35.11",
     "constructs": "^10.4.2",
     "dotenv": "^16.4.7"
   },
   "peerDependencies": {
-    "aws-cdk": "2.177.0",
-    "aws-cdk-lib": "2.177.0",
+    "aws-cdk": "2.178.0",
+    "aws-cdk-lib": "2.178.0",
     "constructs": "^10.4.2"
   }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement, Dependencies

___

### **PR Description**
• Added support for `AuroraPostgresEngineVersion.VER_16_6_LIMITLESS` engine
• Updated AWS CDK dependencies to latest versions
• Improved cluster naming for better clarity
• Conditionally select PostgreSQL engine version based on scalability type
