### PR TITLE
Improve aurora port definition

### DIFF
--- a/lib/AwsAuroraServerlessStackProps.ts
+++ b/lib/AwsAuroraServerlessStackProps.ts
@@ -49,3 +49,10 @@ export enum AuroraEngine {
     /** MySQL-compatible Aurora engine */
     AuroraMysql = "aurora-mysql",
 }
+
+export enum AuroraPort {
+    /** Default port for PostgreSQL-compatible Aurora */
+    PostgreSQL = 5432,
+    /** Default port for MySQL-compatible Aurora */
+    MySQL = 3306
+}


### PR DESCRIPTION
### **PR Type**
Enhancement, Refactoring

___

### **PR Description**
- Introduced `AuroraPort` enum for defining default ports for Aurora engines
  - Added `PostgreSQL` and `MySQL` port values

- Refactored `auroraPort` assignment to use `AuroraPort` enum

- Renamed `kmsKey` to `auroraKmsKey` for clarity
