### PR TITLE
Update core libs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2025-03-09 [PR#67](https://github.com/OpenWorkspace-o1/aws-aurora-serverless/pull/67)
+
+### Changed
+
+- Updated `@types/node` from `22.13.1` to `22.13.10`.
+- Upgraded `aws-cdk` from `2.178.1` to `2.1003.0` and `aws-cdk-lib` from `2.178.1` to `2.182.0`.
+- Updated `ts-jest` from `^29.2.5` to `^29.2.6` and `typescript` from `~5.7.3` to `~5.8.2`.
+- Bumped project version to `0.2.1`.
+
 ## 2025-02-04 [PR#57](https://github.com/OpenWorkspace-o1/aws-aurora-serverless/pull/57)
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-aurora-serverless",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-aurora-serverless",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "aws-cdk-lib": "2.182.0",
         "cdk-nag": "^2.35.40",
@@ -3913,6 +3913,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "aws-aurora-serverless",
       "version": "0.2.0",
       "dependencies": {
-        "aws-cdk-lib": "2.178.1",
-        "cdk-nag": "^2.35.14",
+        "aws-cdk-lib": "2.182.0",
+        "cdk-nag": "^2.35.40",
         "constructs": "^10.4.2",
         "dotenv": "^16.4.7"
       },
@@ -19,17 +19,17 @@
       "devDependencies": {
         "@tsconfig/node22": "^22.0.0",
         "@types/jest": "^29.5.14",
-        "@types/node": "22.13.1",
+        "@types/node": "22.13.10",
         "@types/source-map-support": "^0.5.10",
-        "aws-cdk": "2.178.1",
+        "aws-cdk": "2.1003.0",
         "jest": "^29.7.0",
-        "ts-jest": "^29.2.5",
+        "ts-jest": "^29.2.6",
         "ts-node": "^10.9.2",
-        "typescript": "~5.7.3"
+        "typescript": "~5.8.2"
       },
       "peerDependencies": {
-        "aws-cdk": "2.178.1",
-        "aws-cdk-lib": "2.178.1",
+        "aws-cdk": "2.1003.0",
+        "aws-cdk-lib": "2.182.0",
         "constructs": "^10.4.2"
       }
     },
@@ -53,12 +53,6 @@
       "integrity": "sha512-crm1yDJmORJF2Y9gDvNUX4Q3iQXVhWrL7oaZfpx3QDqrvVz5UEgWGpJdysqDuWFZTmIgtrI5Svq3UfdwCNNpsg==",
       "license": "Apache-2.0"
     },
-    "node_modules/@aws-cdk/asset-kubectl-v20": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.3.tgz",
-      "integrity": "sha512-cDG1w3ieM6eOT9mTefRuTypk95+oyD7P5X/wRltwmYxU7nZc3+076YEVS6vrjDKr3ADYbfn0lDKpfB1FBtO9CQ==",
-      "license": "Apache-2.0"
-    },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
@@ -66,9 +60,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "39.2.14",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-39.2.14.tgz",
-      "integrity": "sha512-G6hudyROAI95rdsKjhOkt3pPC54yx2rqkadeqk5e/xnSX+4NgixK36HJ8giVYNUVFtP12GUeFsQ8NC4ME3GgYg==",
+      "version": "40.7.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-40.7.0.tgz",
+      "integrity": "sha512-00wVKn9pOOGXbeNwA4E8FUFt0zIB4PmSO7PvIiDWgpaFX3G/sWyy0A3s6bg/n2Yvkghu8r4a8ckm+mAzkAYmfA==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -77,6 +71,9 @@
       "dependencies": {
         "jsonschema": "~1.4.1",
         "semver": "^7.7.1"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
@@ -1136,9 +1133,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.13.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.1.tgz",
-      "integrity": "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==",
+      "version": "22.13.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
+      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1286,10 +1283,11 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.178.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.178.1.tgz",
-      "integrity": "sha512-64z9ARFI90jhX6sfjqqJghGxkfh1T4STxY3ccuRY8OxzAK1FY6XLjKBxSyXi9jJFa3v9nN57x7W32u4hZDj6gw==",
+      "version": "2.1003.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1003.0.tgz",
+      "integrity": "sha512-FORPDGW8oUg4tXFlhX+lv/j+152LO9wwi3/CwNr1WY3c3HwJUtc0fZGb2B3+Fzy6NhLWGHJclUsJPEhjEt8Nhg==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "cdk": "bin/cdk"
       },
@@ -1301,9 +1299,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.178.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.178.1.tgz",
-      "integrity": "sha512-Sl6/posIlvfoD3ILHlABaCVw2C84jbhlQ+mA8J3DEFbN2RvrPkG4dz4HQfC5IiXQJigu39kmj73JPQCnSKl2iA==",
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.182.0.tgz",
+      "integrity": "sha512-emymzTJiCpPz8oF++oiFvFuLH1QZjv6NRNQGn7VuDrEewZFTM4VpiVco5NrxH+KCWnXquDBPF5sQIUo6HY7jLg==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1317,11 +1315,11 @@
         "yaml",
         "mime-types"
       ],
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "^2.2.208",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.3",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-        "@aws-cdk/cloud-assembly-schema": "^39.2.0",
+        "@aws-cdk/cloud-assembly-schema": "^40.6.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.2.0",
@@ -1902,9 +1900,10 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/cdk-nag": {
-      "version": "2.35.14",
-      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.35.14.tgz",
-      "integrity": "sha512-UNagzKa0bri/N6p1hycqIoue67KfzuIKQrGrGcsEWhTbJ3dxR0vYgKMQwCltm2dSa9irX3JXcNYyDnJNxfm+SA==",
+      "version": "2.35.40",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.35.40.tgz",
+      "integrity": "sha512-S2zo25FTYLNY7uHRFKT4Hlapf8kGuTe9b/MIIxY5PXV76ZeCjhii6AsaV2hhIPx983ckbvv8cnjINoJATpKmcA==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "aws-cdk-lib": "^2.156.0",
         "constructs": "^10.0.5"
@@ -3914,7 +3913,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4145,9 +4143,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.2.5",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.5.tgz",
-      "integrity": "sha512-KD8zB2aAZrcKIdGk4OwpJggeLcH1FgrICqDSROWqlnJXGCXK4Mn6FcdK2B6670Xr73lHMG1kHw8R87A0ecZ+vA==",
+      "version": "29.2.6",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.6.tgz",
+      "integrity": "sha512-yTNZVZqc8lSixm+QGVFcPe6+yj7+TWZwIesuOWvfcn4B9bz5x4NDzVCQQjOs7Hfouu36aEqfEbo9Qpo+gq8dDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4158,7 +4156,7 @@
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.6.3",
+        "semver": "^7.7.1",
         "yargs-parser": "^21.1.1"
       },
       "bin": {
@@ -4194,9 +4192,9 @@
       }
     },
     "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4274,9 +4272,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-aurora-serverless",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "bin": {
     "aws-aurora-serverless": "bin/aws-aurora-serverless.js"
   },

--- a/package.json
+++ b/package.json
@@ -13,23 +13,23 @@
   "devDependencies": {
     "@tsconfig/node22": "^22.0.0",
     "@types/jest": "^29.5.14",
-    "@types/node": "22.13.1",
+    "@types/node": "22.13.10",
     "@types/source-map-support": "^0.5.10",
-    "aws-cdk": "2.178.1",
+    "aws-cdk": "2.1003.0",
     "jest": "^29.7.0",
-    "ts-jest": "^29.2.5",
+    "ts-jest": "^29.2.6",
     "ts-node": "^10.9.2",
-    "typescript": "~5.7.3"
+    "typescript": "~5.8.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.178.1",
-    "cdk-nag": "^2.35.14",
+    "aws-cdk-lib": "2.182.0",
+    "cdk-nag": "^2.35.40",
     "constructs": "^10.4.2",
     "dotenv": "^16.4.7"
   },
   "peerDependencies": {
-    "aws-cdk": "2.178.1",
-    "aws-cdk-lib": "2.178.1",
+    "aws-cdk": "2.1003.0",
+    "aws-cdk-lib": "2.182.0",
     "constructs": "^10.4.2"
   }
 }


### PR DESCRIPTION
### **PR Type**
Dependencies

___

### **PR Description**
- Updated `@types/node` from `22.13.1` to `22.13.10`.

- Upgraded `aws-cdk` from `2.178.1` to `2.1003.0`.

- Upgraded `aws-cdk-lib` from `2.178.1` to `2.182.0`.

- Updated `ts-jest` from `^29.2.5` to `^29.2.6` and `typescript` from `~5.7.3` to `~5.8.2`.
