### PR TITLE
`v0.2.7`

### DIFF
--- a/lib/aws-aurora-serverless-stack.ts
+++ b/lib/aws-aurora-serverless-stack.ts
@@ -50,7 +50,7 @@ export class AwsAuroraServerlessStack extends cdk.Stack {
       removalPolicy: cdk.RemovalPolicy.DESTROY,
     });
 
-    const auroraKmsKey = new kms.Key(this, `${props.resourcePrefix}-Aurora-KMS-Key`, {
+    const auroraStorageEncryptionKmsKey = new kms.Key(this, `${props.resourcePrefix}-Aurora-Storage-Encryption-KMS-Key`, {
       enabled: true,
       enableKeyRotation: true,
       rotationPeriod: cdk.Duration.days(90),
@@ -119,11 +119,11 @@ export class AwsAuroraServerlessStack extends cdk.Stack {
       writer: rds.ClusterInstance.serverlessV2(AuroraClusterInstanceType.Writer),
       readers: [
         rds.ClusterInstance.serverlessV2(AuroraClusterInstanceType.Reader, {
-          scaleWithWriter: true,
+          scaleWithWriter: false,
         }),
       ],
       storageEncrypted: true,
-      storageEncryptionKey: auroraKmsKey,
+      storageEncryptionKey: auroraStorageEncryptionKmsKey,
       credentials: rds.Credentials.fromPassword(props.rdsUsername, SecretValue.unsafePlainText(props.rdsPassword)),
       removalPolicy,
       iamAuthentication: true,
@@ -189,16 +189,16 @@ export class AwsAuroraServerlessStack extends cdk.Stack {
       exportName: `${props.resourcePrefix}-Aurora-Security-Group-ID`,
     });
 
-    new cdk.CfnOutput(this, `${props.resourcePrefix}-Aurora-KMS-Key-ID`, {
-      value: auroraKmsKey.keyId,
-      description: 'Aurora KMS Key ID',
-      exportName: `${props.resourcePrefix}-Aurora-KMS-Key-ID`,
+    new cdk.CfnOutput(this, `${props.resourcePrefix}-Aurora-Storage-Encryption-KMS-Key-ID`, {
+      value: auroraStorageEncryptionKmsKey.keyId,
+      description: 'Aurora Storage Encryption KMS Key ID',
+      exportName: `${props.resourcePrefix}-Aurora-Storage-Encryption-KMS-Key-ID`,
     });
 
-    new cdk.CfnOutput(this, `${props.resourcePrefix}-Aurora-KMS-Key-ARN`, {
-      value: auroraKmsKey.keyArn,
-      description: 'Aurora KMS Key ARN',
-      exportName: `${props.resourcePrefix}-Aurora-KMS-Key-ARN`,
+    new cdk.CfnOutput(this, `${props.resourcePrefix}-Aurora-Storage-Encryption-KMS-Key-ARN`, {
+      value: auroraStorageEncryptionKmsKey.keyArn,
+      description: 'Aurora Storage Encryption KMS Key ARN',
+      exportName: `${props.resourcePrefix}-Aurora-Storage-Encryption-KMS-Key-ARN`,
     });
 
     new cdk.CfnOutput(this, `${props.resourcePrefix}-Aurora-Port`, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "aws-aurora-serverless",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-aurora-serverless",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "dependencies": {
-        "aws-cdk-lib": "2.203.1",
+        "aws-cdk-lib": "2.204.0",
         "cdk-nag": "^2.36.33",
         "constructs": "^10.4.2",
         "dotenv": "^17.0.1"
@@ -21,15 +21,15 @@
         "@types/jest": "^30.0.0",
         "@types/node": "22.16.0",
         "@types/source-map-support": "^0.5.10",
-        "aws-cdk": "2.1020.1",
+        "aws-cdk": "2.1020.2",
         "jest": "^30.0.4",
         "ts-jest": "^29.4.0",
         "ts-node": "^10.9.2",
         "typescript": "~5.8.3"
       },
       "peerDependencies": {
-        "aws-cdk": "2.1020.1",
-        "aws-cdk-lib": "2.203.1",
+        "aws-cdk": "2.1020.2",
+        "aws-cdk-lib": "2.204.0",
         "constructs": "^10.4.2"
       }
     },
@@ -60,9 +60,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "44.9.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-44.9.0.tgz",
-      "integrity": "sha512-zQ/CwW/CZ3Zcf2vdukBCHbZi8wwYuoVIRU7w6dWS7Y7wPuq7iWTWwQyujvH5YlDVMyH4mrgYa3f1lV2etTZLVQ==",
+      "version": "45.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-45.1.0.tgz",
+      "integrity": "sha512-vMV6nbV2dwqX3FO1PFPGXw9GzBmP30nnixHZQrT+Q6yatAt6xmj/dK4GLxzl/sFP3ItgMzBvgEekRL6Ajf4taw==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -1702,9 +1702,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.1020.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1020.1.tgz",
-      "integrity": "sha512-4UG9qzf6ZSDjINubcukPZChVj6PvDJAHiURAw0jYSkUhObPkX7Zo9uNUIlXzrM+hpB2N2jwRKY9b3sN+KDbtAQ==",
+      "version": "2.1020.2",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1020.2.tgz",
+      "integrity": "sha512-yWdt3dJh4aPm1VNyEgfG3lozGrvddw0i7avt+Cl9KOYixmisQtAg39/aZqzVVqjzVZVEanXmz+tlhzzh75Z69A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1718,9 +1718,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.203.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.203.1.tgz",
-      "integrity": "sha512-tvxWV0aGk4UJngcDfkHL7SOx4kE1xZXNlf5x8Hw7tBLtvwwRHQ65JwFleEBQ93jOBF0pXDEruHXV/f3sfmHfBQ==",
+      "version": "2.204.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.204.0.tgz",
+      "integrity": "sha512-mY3nYu+QvPhO+fz+LCFKbc0PFhTHbHzDLnbcA2fPcQBKciYnTixpBd2ccRlKYWbG4y6NTc6ju6DudZ3HIS4OlA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1738,7 +1738,7 @@
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.242",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-        "@aws-cdk/cloud-assembly-schema": "^44.8.0",
+        "@aws-cdk/cloud-assembly-schema": "^45.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-aurora-serverless",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "bin": {
     "aws-aurora-serverless": "bin/aws-aurora-serverless.js"
   },
@@ -15,21 +15,21 @@
     "@types/jest": "^30.0.0",
     "@types/node": "22.16.0",
     "@types/source-map-support": "^0.5.10",
-    "aws-cdk": "2.1020.1",
+    "aws-cdk": "2.1020.2",
     "jest": "^30.0.4",
     "ts-jest": "^29.4.0",
     "ts-node": "^10.9.2",
     "typescript": "~5.8.3"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.203.1",
+    "aws-cdk-lib": "2.204.0",
     "cdk-nag": "^2.36.33",
     "constructs": "^10.4.2",
     "dotenv": "^17.0.1"
   },
   "peerDependencies": {
-    "aws-cdk": "2.1020.1",
-    "aws-cdk-lib": "2.203.1",
+    "aws-cdk": "2.1020.2",
+    "aws-cdk-lib": "2.204.0",
     "constructs": "^10.4.2"
   }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement, Dependencies

___

### **PR Description**
- Renamed `auroraKmsKey` to `auroraStorageEncryptionKmsKey` for clarity.

- Updated AWS CDK dependencies to newer versions.
  - `aws-cdk` from `2.1020.1` to `2.1020.2`.
  - `aws-cdk-lib` from `2.203.1` to `2.204.0`.

- Changed reader instance configuration to not scale with writer.

- Updated package version from `0.2.6` to `0.2.7`.
